### PR TITLE
react-draggable instead of react-clickdrag

### DIFF
--- a/electron.js
+++ b/electron.js
@@ -1,56 +1,53 @@
-const electron = require('electron')
+const electron = require('electron');
 // Module to control application life.
-const app = electron.app
+const app = electron.app;
 // Module to create native browser window.
-const BrowserWindow = electron.BrowserWindow
-
-const path = require('path')
-const url = require('url')
+const BrowserWindow = electron.BrowserWindow;
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
-let mainWindow
+let mainWindow;
 
-function createWindow () {
-  // Create the browser window.
-  mainWindow = new BrowserWindow({width: 800, height: 600})
+function createWindow() {
+    // Create the browser window.
+    mainWindow = new BrowserWindow({width: 800, height: 600});
 
-  // and load the index.html of the app.
-  mainWindow.loadURL('http://localhost:3000')
+    // and load the index.html of the app.
+    mainWindow.loadURL('http://localhost:3000');
 
-  // Open the DevTools.
-  // mainWindow.webContents.openDevTools()
+    // Open the DevTools.
+    // mainWindow.webContents.openDevTools()
 
-  // Emitted when the window is closed.
-  mainWindow.on('closed', function () {
-    // Dereference the window object, usually you would store windows
-    // in an array if your app supports multi windows, this is the time
-    // when you should delete the corresponding element.
-    mainWindow = null
-  })
+    // Emitted when the window is closed.
+    mainWindow.on('closed', function() {
+        // Dereference the window object, usually you would store windows
+        // in an array if your app supports multi windows, this is the time
+        // when you should delete the corresponding element.
+        mainWindow = null;
+    });
 }
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.on('ready', createWindow)
+app.on('ready', createWindow);
 
 // Quit when all windows are closed.
-app.on('window-all-closed', function () {
-  // On OS X it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
-  if (process.platform !== 'darwin') {
-    app.quit()
-  }
-})
+app.on('window-all-closed', function() {
+    // On OS X it is common for applications and their menu bar
+    // to stay active until the user quits explicitly with Cmd + Q
+    if (process.platform !== 'darwin') {
+        app.quit();
+    }
+});
 
-app.on('activate', function () {
-  // On OS X it's common to re-create a window in the app when the
-  // dock icon is clicked and there are no other windows open.
-  if (mainWindow === null) {
-    createWindow()
-  }
-})
+app.on('activate', function() {
+    // On OS X it's common to re-create a window in the app when the
+    // dock icon is clicked and there are no other windows open.
+    if (mainWindow === null) {
+        createWindow();
+    }
+});
 
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "guid": "^0.0.12",
     "jsondiffpatch": "^0.2.4",
     "react": "^15.6.1",
-    "react-clickdrag": "^3.0.2",
     "react-dom": "^15.6.1",
+    "react-draggable": "^3.0.3",
     "react-redux": "^5.0.6",
     "react-scripts": "1.0.13",
     "redux": "^3.7.2"

--- a/src/components/drawing/Canvas.js
+++ b/src/components/drawing/Canvas.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import clickdrag from 'react-clickdrag';
 import PropTypes from 'prop-types';
+import { DraggableCore } from 'react-draggable';
 import './Canvas.css';
 import Shape from './Shape';
 
@@ -8,9 +8,9 @@ class Canvas extends Component {
     static propTypes = {
         shapes: PropTypes.array,
         dataDrag: PropTypes.object,
-        onCanvasDragStart: PropTypes.func,
-        onCanvasDrag: PropTypes.func,
-        onCanvasDragStop: PropTypes.func,
+        onDragStart: PropTypes.func,
+        onDrag: PropTypes.func,
+        onDragStop: PropTypes.func,
         onUndoClick: PropTypes.func,
         onRedoClick: PropTypes.func
     };
@@ -19,42 +19,23 @@ class Canvas extends Component {
         super(props);
 
         this.renderDrawing = this.renderDrawing.bind(this);
-        this.handleCanvasDragStart = this.handleCanvasDragStart.bind(this);
-        this.handleCanvasDrag = this.handleCanvasDrag.bind(this);
-        this.handleCanvasDragStop = this.handleCanvasDragStop.bind(this);
         this.handleUndoClick = this.handleUndoClick.bind(this);
         this.handleRedoClick = this.handleRedoClick.bind(this);
+        this.handleDragStart = this.handleDragStart.bind(this);
+        this.handleDrag = this.handleDrag.bind(this);
+        this.handleDragStop = this.handleDragStop.bind(this);
     }
 
-    componentWillReceiveProps(nextProps) {
-        const dataDrag = this.props.dataDrag;
-        const nextDataDrag = nextProps.dataDrag;
-        if (!dataDrag.isMouseDown && nextDataDrag.isMouseDown) {
-            this.handleCanvasDragStart({
-                x: nextDataDrag.mouseDownPositionX,
-                y: nextDataDrag.mouseDownPositionY
-            });
-        }
-
-        const moveDeltaXChanged = dataDrag.moveDeltaX !== nextDataDrag.moveDeltaX;
-        const moveDeltaYChanged = dataDrag.moveDeltaY !== nextDataDrag.moveDeltaY;
-        if (moveDeltaXChanged && moveDeltaYChanged) {
-            this.handleCanvasDrag(nextDataDrag);
-        } else if (dataDrag.isMoving && !nextDataDrag.isMoving) {
-            this.handleCanvasDragStop(nextDataDrag);
-        }
+    handleDragStart(e, draggableData) {
+        this.props.onDragStart(draggableData);
     }
 
-    handleCanvasDragStart({x, y}) {
-        this.props.onCanvasDragStart({x, y});
+    handleDrag(e, draggableData) {
+        this.props.onDrag(draggableData);
     }
 
-    handleCanvasDrag(dataDrag) {
-        this.props.onCanvasDrag(dataDrag);
-    }
-
-    handleCanvasDragStop(dataDrag) {
-        this.props.onCanvasDragStop(dataDrag);
+    handleDragStop(e, draggableData) {
+        this.props.onDragStop();
     }
 
     handleUndoClick() {
@@ -76,6 +57,9 @@ class Canvas extends Component {
                     y={shape.y}
                     id={shape.id}
                     key={shape.id}
+                    onDragStart={() => { console.log("drag start"); }}
+                    onDrag={() => { console.log("draggin"); }}
+                    onDragStop={() => { console.log("drag stop"); }}
                 />
             );
         });
@@ -86,12 +70,18 @@ class Canvas extends Component {
             <div>
                 <button onClick={this.handleUndoClick}>UNDO</button>
                 <button onClick={this.handleRedoClick}>REDO</button>
-                <svg className="Canvas" height="900" width="1200">
-                    {this.renderDrawing()}
-                </svg>
+                <DraggableCore
+                    onStart={this.handleDragStart}
+                    onDrag={this.handleDrag}
+                    onStop={this.handleDragStop}
+                >
+                    <svg className="Canvas" height="900" width="1200">
+                        {this.renderDrawing()}
+                    </svg>
+                </DraggableCore>
             </div>
         );
     }
 }
 
-export default clickdrag(Canvas);
+export default Canvas;

--- a/src/components/drawing/CanvasContainer.js
+++ b/src/components/drawing/CanvasContainer.js
@@ -20,13 +20,13 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
     return {
-        onCanvasDragStart: ({x, y}) => {
-            dispatch(canvasDragStart({x, y}));
+        onDragStart: ({x, y, node}) => {
+            dispatch(canvasDragStart({x, y, node}));
         },
-        onCanvasDrag: ({mouseDownPositionX, mouseDownPositionY, moveDeltaX, moveDeltaY}) => {
-            dispatch(canvasDrag({mouseDownPositionX, mouseDownPositionY, moveDeltaX, moveDeltaY}));
+        onDrag: ({x, y, deltaX, deltaY, node}) => {
+            dispatch(canvasDrag({x, y, deltaX, deltaY, node}));
         },
-        onCanvasDragStop: ({mouseDownPositionX, mouseDownPositionY, moveDeltaX, moveDeltaY}) => {
+        onDragStop: () => {
             dispatch(canvasDragStop());
         },
         onUndoClick: () => {

--- a/src/components/drawing/Shape.js
+++ b/src/components/drawing/Shape.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { DraggableCore } from 'react-draggable';
 
 class Shape extends Component {
     static propTypes = {
@@ -7,19 +8,51 @@ class Shape extends Component {
         width: PropTypes.number,
         height: PropTypes.number,
         x: PropTypes.number,
-        y: PropTypes.number
+        y: PropTypes.number,
+        onDragStart: PropTypes.func,
+        onDrag: PropTypes.func,
+        onDragStop: PropTypes.func
+    }
+
+    constructor(props) {
+        super(props);
+
+        this.handleDragStart = this.handleDragStart.bind(this);
+        this.handleDrag = this.handleDrag.bind(this);
+        this.handleDragStop = this.handleDragStop.bind(this);
+    }
+
+    handleDragStart(e, draggableData) {
+        e.stopPropagation();
+        this.props.onDragStart(draggableData);
+    }
+
+    handleDrag(e, draggableData) {
+        e.stopPropagation();
+        this.props.onDrag(draggableData);
+    }
+
+    handleDragStop(e, draggableData) {
+        e.stopPropagation();
+        this.props.onDragStop();
     }
 
     render() {
         const { width, height, x, y } = this.props;
 
         return (
-            <rect
-                width={width}
-                height={height}
-                x={x}
-                y={y}
-            />
+            <DraggableCore
+                onStart={this.handleDragStart}
+                onDrag={this.handleDrag}
+                onStop={this.handleDragStop}
+            >
+                <rect
+                    width={width}
+                    height={height}
+                    x={x}
+                    y={y}
+                />
+            </DraggableCore>
         );
     }
 }

--- a/src/reducers/functions/shape.js
+++ b/src/reducers/functions/shape.js
@@ -8,21 +8,23 @@ export function resizeShape(state, action) {
     updatedState.drawing = Object.assign({}, state.drawing);
 
     const shape = Object.assign({}, state.drawing[state.selected[0]]);
+    const mouseX = action.shape.x - action.shape.node.getBoundingClientRect().left;
+    const mouseY = action.shape.y - action.shape.node.getBoundingClientRect().top;
 
-    if (action.shape.moveDeltaX > 0) {
-        shape.x = action.shape.mouseDownPositionX;
-        shape.width = action.shape.moveDeltaX;
-    } else {
-        shape.x = action.shape.mouseDownPositionX + action.shape.moveDeltaX;
-        shape.width = -action.shape.moveDeltaX;
+    if (mouseX > shape.originX) {
+        shape.x = shape.originX;
+        shape.width = mouseX - shape.x;
+    } else if (mouseX < shape.originX) {
+        shape.x = mouseX;
+        shape.width = shape.originX - mouseX;
     }
 
-    if (action.shape.moveDeltaY > 0) {
-        shape.y = action.shape.mouseDownPositionY;
-        shape.height = action.shape.moveDeltaY;
-    } else {
-        shape.y = action.shape.mouseDownPositionY + action.shape.moveDeltaY;
-        shape.height = -action.shape.moveDeltaY;
+    if (mouseY > shape.originY) {
+        shape.y = shape.originY;
+        shape.height = mouseY - shape.y;
+    } else if (mouseY < shape.originY) {
+        shape.y = mouseY;
+        shape.height = shape.originY - mouseY;
     }
 
     updatedState.drawing[state.selected[0]] = shape;
@@ -31,10 +33,14 @@ export function resizeShape(state, action) {
 }
 
 function createSquare(shape) {
+    const x = shape.x - shape.node.getBoundingClientRect().left;
+    const y = shape.y - shape.node.getBoundingClientRect().top;
     const newShape = {};
     newShape.id = guid.create();
-    newShape.x = shape.x;
-    newShape.y = shape.y;
+    newShape.originX = x;
+    newShape.originY = y;
+    newShape.x = x;
+    newShape.y = y;
     newShape.width = 0;
     newShape.height = 0;
     return newShape;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1360,6 +1360,10 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
+classnames@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
+
 clean-css@4.1.x:
   version "4.1.8"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.8.tgz#061455b2494a750ac98f46d8d5ebb17c679ea9d1"
@@ -5339,10 +5343,6 @@ rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-clickdrag@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/react-clickdrag/-/react-clickdrag-3.0.2.tgz#54df5f3df6d695c54e9978a08253f83de7611bd2"
-
 react-dev-utils@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-4.0.1.tgz#106ae3d29f811c169d459bb9215a5933b7e11fb6"
@@ -5373,6 +5373,13 @@ react-dev-utils@^4.0.1:
     fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "^15.5.10"
+
+react-draggable@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-3.0.3.tgz#a6f9b3a7171981b76dadecf238316925cb9eacf4"
+  dependencies:
+    classnames "^2.2.5"
     prop-types "^15.5.10"
 
 react-error-overlay@^2.0.1:


### PR DESCRIPTION
This PR changes our dragging library to react-draggable. It eliminates the weird lag we were seeing when we would drag slowly.

This also required changes to the backend. Now when a drag event is called, we only get the mouse position in screen coordinates (rather than component coordinates) and the delta x and y relative to the last coordinates. Luckily, the drag data also includes the component HTMLElement, which we can use to get the position of the component and convert screen coordinates to component coordinates
