### PR TITLE
Track State of Keyboard

### DIFF
--- a/electron.js
+++ b/electron.js
@@ -11,6 +11,7 @@ let mainWindow;
 function createWindow() {
     // Create the browser window.
     mainWindow = new BrowserWindow({width: 800, height: 600});
+    mainWindow.focus();
 
     // and load the index.html of the app.
     mainWindow.loadURL('http://localhost:3000');

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,43 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { CanvasContainer } from './components/drawing';
 import { MenuContainer } from './components/horz-menu';
 
 class App extends Component {
+    static propTypes = {
+        onKeyDown: PropTypes.func,
+        onKeyUp: PropTypes.func
+    }
+
+    constructor(props) {
+        super(props);
+
+        this.handleKeyDown = this.handleKeyDown.bind(this);
+        this.handleKeyUp = this.handleKeyUp.bind(this);
+    }
+
+    componentDidMount() {
+        this.app.focus();
+    }
+
+    handleKeyDown(e) {
+        const { onKeyDown } = this.props;
+        onKeyDown && onKeyDown(e.nativeEvent.keyCode);
+    }
+
+    handleKeyUp(e) {
+        const { onKeyUp } = this.props;
+        onKeyUp && onKeyUp(e.nativeEvent.keyCode);
+    }
+
     render() {
         return (
-            <div className="App">
+            <div className="App"
+                ref={el => { this.app = el; }}
+                onKeyDown={this.handleKeyDown}
+                onKeyUp={this.handleKeyUp}
+                tabIndex={-1}
+            >
                 <MenuContainer />
                 <CanvasContainer />
             </div>

--- a/src/AppContainer.js
+++ b/src/AppContainer.js
@@ -1,0 +1,19 @@
+import { connect } from 'react-redux';
+import { keyUp, keyDown } from './actions/menu';
+import App from './App';
+
+const mapDispatchToProps = (dispatch) => {
+    return {
+        onKeyDown: (keyCode) => {
+            dispatch(keyDown(keyCode));
+        },
+        onKeyUp: (keyCode) => {
+            dispatch(keyUp(keyCode));
+        }
+    };
+};
+
+export default connect(
+    undefined,
+    mapDispatchToProps
+)(App);

--- a/src/actions/menu.js
+++ b/src/actions/menu.js
@@ -1,6 +1,16 @@
+export const KEY_DOWN = 'KEY_DOWN';
+export const KEY_UP = 'KEY_UP';
 export const SELECT_TOOL = 'SELECT_TOOL';
 export const UNDO_CLICK = 'UNDO_CLICK';
 export const REDO_CLICK = 'REDO_CLICK';
+
+export function keyDown(keyCode) {
+    return { type: KEY_DOWN, payload: { keyCode } };
+}
+
+export function keyUp(keyCode) {
+    return { type: KEY_UP, payload: { keyCode } };
+}
 
 export function selectTool(toolType) {
     return { type: SELECT_TOOL, payload: { toolType } };

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
-import App from './App';
+import AppContainer from './AppContainer';
 import registerServiceWorker from './registerServiceWorker';
 
 import { createStore } from 'redux';
@@ -12,7 +12,7 @@ let store = createStore(reducer);
 
 ReactDOM.render(
     <Provider store={store}>
-        <App />
+        <AppContainer />
     </Provider>,
     document.getElementById('root'));
 registerServiceWorker();

--- a/src/reducers/caseFunctions/menu.js
+++ b/src/reducers/caseFunctions/menu.js
@@ -1,6 +1,22 @@
 import jsondiffpatch from 'jsondiffpatch';
 import { generateSelectionBoxes } from '../utilities/selection';
 
+export function keyDown(stateCopy, action) {
+    const { keyCode } = action.payload;
+    if (!stateCopy.currentKeys[keyCode]) {
+        stateCopy.currentKeys[keyCode] = true;
+    }
+    return stateCopy;
+}
+
+export function keyUp(stateCopy, action) {
+    const { keyCode } = action.payload;
+    if (stateCopy.currentKeys[keyCode]) {
+        delete stateCopy.currentKeys[keyCode];
+    }
+    return stateCopy;
+}
+
 export function undoClick(stateCopy, action) {
     const delta = stateCopy.past.pop();
 

--- a/src/reducers/menuState.js
+++ b/src/reducers/menuState.js
@@ -3,13 +3,18 @@ import * as menu from './caseFunctions/menu';
 import { deepCopy } from './utilities/object';
 
 const initialState = {
-    toolType: ''
+    toolType: '',
+    currentKeys: {}
 };
 
 function menuState(state = initialState, action) {
     const stateCopy = deepCopy(state);
 
     switch (action.type) {
+        case menuActions.KEY_DOWN:
+            return menu.keyDown(stateCopy, action);
+        case menuActions.KEY_UP:
+            return menu.keyUp(stateCopy, action);
         case menuActions.SELECT_TOOL:
             return menu.selectTool(stateCopy, action);
         default:


### PR DESCRIPTION
Add currentKeys to menuState which has a JS object of the key codes of all keys currently pressed. The key of the JS object is the key code and the value is just boolean true. I left a couple of console statements in there for clarity.
This part of the state will be useful for held down keys, such as shift with multi-select. For keys like delete, we'll probably want to detect the press of the key and just call an action directly.