### PR TITLE
Propagate Some Events to Canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
-    "electron": "electron ."
+    "electron": "electron .",
+    "eslint": "./node_modules/.bin/eslint"
   },
   "devDependencies": {
     "electron": "1.7.8"

--- a/src/components/drawing/Canvas.js
+++ b/src/components/drawing/Canvas.js
@@ -22,7 +22,8 @@ class Canvas extends Component {
         onHandleDrag: PropTypes.func,
         onHandleDragStop: PropTypes.func,
         onUndoClick: PropTypes.func,
-        onRedoClick: PropTypes.func
+        onRedoClick: PropTypes.func,
+        propagateEvents: PropTypes.bool
     };
 
     constructor(props) {
@@ -111,6 +112,7 @@ class Canvas extends Component {
     }
 
     renderHandles(shape) {
+        const { propagateEvents } = this.props;
         return [0, 1, 2, 3].map((index) => {
             let x = shape.x - 3;
             let y = shape.y - 3;
@@ -131,12 +133,14 @@ class Canvas extends Component {
                     onDragStart={this.handleHandleDragStart}
                     onDrag={this.handleHandleDrag}
                     onDragStop={this.handleHandleDragStop}
+                    propagateEvents={propagateEvents}
                 />
             );
         });
     }
 
     renderShape(shape) {
+        const { propagateEvents } = this.props;
         switch (shape.type) {
             case 'group':
                 const groupMembers = shape.members.map((shape) => {
@@ -164,6 +168,7 @@ class Canvas extends Component {
                         onDragStop={this.handleShapeDragStop}
                         onClick={this.handleShapeClick}
                         {...shape}
+                        propagateEvents={propagateEvents}
                     />
                 );
             case 'selectionBox':
@@ -177,6 +182,7 @@ class Canvas extends Component {
                             stroke='rgba(102, 204, 255, 0.7)'
                             strokeWidth={2}
                             fill='none'
+                            propagateEvents={propagateEvents}
                         />
                         {this.renderHandles(shape)}
                     </g>

--- a/src/components/drawing/CanvasContainer.js
+++ b/src/components/drawing/CanvasContainer.js
@@ -27,8 +27,9 @@ function formatShape(shape, shapes) {
     return formattedShape;
 }
 
-const mapStateToProps = ({ drawingState }) => {
+const mapStateToProps = ({ drawingState, menuState }) => {
     const { shapes, selectionBoxes } = drawingState;
+    const { toolType } = menuState;
     const formattedShapes = shapes.allIds.map((id) => {
         return formatShape(shapes.byId[id], shapes);
     });
@@ -37,7 +38,8 @@ const mapStateToProps = ({ drawingState }) => {
     });
 
     return {
-        shapes: formattedShapes
+        shapes: formattedShapes,
+        propagateEvents: toolType === 'rectangleTool'
     };
 };
 

--- a/src/components/drawing/Handle.js
+++ b/src/components/drawing/Handle.js
@@ -11,7 +11,8 @@ class Handle extends Component {
         onDrag: PropTypes.func,
         onDragStop: PropTypes.func,
         x: PropTypes.number,
-        y: PropTypes.number
+        y: PropTypes.number,
+        propagateEvents: PropTypes.bool
     }
 
     constructor(props) {
@@ -38,7 +39,7 @@ class Handle extends Component {
     }
 
     render() {
-        const { id, x, y } = this.props;
+        const { id, x, y, propagateEvents } = this.props;
         const rectProps = { x, y };
 
         return (
@@ -52,6 +53,7 @@ class Handle extends Component {
                 onDragStart={this.handleDragStart}
                 onDrag={this.handleDrag}
                 onDragStop={this.handleDragStop}
+                propagateEvents={propagateEvents}
             />
         );
     }

--- a/src/components/drawing/Rectangle.js
+++ b/src/components/drawing/Rectangle.js
@@ -15,7 +15,12 @@ class Rectangle extends Component {
         y: PropTypes.number,
         stroke: PropTypes.string,
         strokeWidth: PropTypes.number,
-        fill: PropTypes.string
+        fill: PropTypes.string,
+        propagateEvents: PropTypes.bool
+    }
+
+    defaultProps = {
+        propagateEvents: false
     }
 
     constructor(props) {
@@ -48,7 +53,7 @@ class Rectangle extends Component {
     }
 
     render() {
-        const { id, width, height, x, y, stroke, strokeWidth, fill } = this.props;
+        const { id, width, height, x, y, stroke, strokeWidth, fill, propagateEvents } = this.props;
         let renderX = x;
         let renderWidth = Math.abs(width);
         if (width < 0) {
@@ -60,6 +65,7 @@ class Rectangle extends Component {
             renderY = y - renderHeight;
         }
         const rectProps = {
+            id,
             x: renderX,
             y: renderY,
             width: renderWidth,
@@ -76,6 +82,7 @@ class Rectangle extends Component {
                 onDrag={this.handleDrag}
                 onDragStop={this.handleDragStop}
                 onClick={this.handleClick}
+                propagateEvents={propagateEvents}
             >
                 <rect {...rectProps} />
             </Shape>

--- a/src/components/drawing/Shape.js
+++ b/src/components/drawing/Shape.js
@@ -9,7 +9,12 @@ class Shape extends Component {
         onDragStart: PropTypes.func,
         onDrag: PropTypes.func,
         onDragStop: PropTypes.func,
-        onClick: PropTypes.func
+        onClick: PropTypes.func,
+        propagateEvents: PropTypes.bool
+    }
+
+    static defaultProps = {
+        propagateEvents: false
     }
 
     constructor(props) {
@@ -43,13 +48,14 @@ class Shape extends Component {
     }
 
     render() {
-        const { children } = this.props;
+        const { children, propagateEvents } = this.props;
 
         return (
             <Draggable
                 onStart={this.handleDragStart}
                 onDrag={this.handleDrag}
                 onStop={this.handleDragStop}
+                propagateEvents={propagateEvents}
             >
                 {React.cloneElement(children, { onClick: this.handleClick })}
             </Draggable>

--- a/src/components/shared/Draggable.js
+++ b/src/components/shared/Draggable.js
@@ -7,7 +7,12 @@ class Draggable extends Component {
         children: PropTypes.any,
         onStart: PropTypes.func,
         onDrag: PropTypes.func,
-        onStop: PropTypes.func
+        onStop: PropTypes.func,
+        propagateEvents: PropTypes.bool
+    }
+
+    static defaultProps = {
+        propagateEvents: false
     }
 
     constructor(props) {
@@ -24,8 +29,10 @@ class Draggable extends Component {
     }
 
     handleDragStart(e, draggableData) {
-        e.stopPropagation();
-        const { onStart } = this.props;
+        const { onStart, propagateEvents } = this.props;
+        if (!propagateEvents) {
+            e.stopPropagation();
+        }
         this.setState({
             originX: draggableData.x,
             originY: draggableData.y
@@ -34,17 +41,21 @@ class Draggable extends Component {
     }
 
     handleDrag(e, draggableData) {
-        e.stopPropagation();
-        const { onDrag } = this.props;
+        const { onDrag, propagateEvents } = this.props;
         const { originX, originY } = this.state;
+        if (!propagateEvents) {
+            e.stopPropagation();
+        }
         draggableData.originX = originX;
         draggableData.originY = originY;
         onDrag && onDrag(draggableData);
     }
 
     handleDragStop(e, draggableData) {
-        e.stopPropagation();
-        const { onStop } = this.props;
+        const { onStop, propagateEvents } = this.props;
+        if (!propagateEvents) {
+            e.stopPropagation();
+        }
         this.setState({
             originX: null,
             originY: null

--- a/src/reducers/caseFunctions/shape.js
+++ b/src/reducers/caseFunctions/shape.js
@@ -1,4 +1,4 @@
-import { addShape, removeShape, resizeShape, moveShape, fillShape, changeZIndex } from '../utilities/shapes';
+import { addShape, resizeShape, moveShape, fillShape, changeZIndex } from '../utilities/shapes';
 import { selectShape, generateSelectionBoxes, updateSelectionBoxes } from '../utilities/selection';
 
 export function click(stateCopy, action, root) {
@@ -13,16 +13,6 @@ export function click(stateCopy, action, root) {
                 }
                 stateCopy.selected = selectShape(stateCopy.selected, action.payload.shapeId, selectMultiple, shiftSelected);
                 stateCopy.selectionBoxes = generateSelectionBoxes(stateCopy.selected, stateCopy.shapes);
-            }
-            break;
-        case "rectangleTool":
-            const shapeIds = stateCopy.shapes.allIds;
-            const addedShapeId = shapeIds[shapeIds.length - 1];
-            if (Math.abs(stateCopy.shapes.byId[addedShapeId].width) < 1 ||
-                  Math.abs(stateCopy.shapes.byId[addedShapeId].height) < 1) {
-                stateCopy.shapes = removeShape(stateCopy.shapes, addedShapeId);
-                stateCopy.selected = selectShape([], null);
-                stateCopy.selectionBoxes = generateSelectionBoxes([], []);
             }
             break;
         default: break;
@@ -46,13 +36,6 @@ export function drag(stateCopy, action, root) {
         stateCopy.editInProgress = true;
         stateCopy.lastSavedShapes = root.drawingState.shapes;
         switch (root.menuState.toolType) {
-            case "rectangleTool":
-                stateCopy.shapes = addShape(stateCopy.shapes, action, root.menuState.color);
-                const shapeIds = stateCopy.shapes.allIds;
-                const addedShapeId = shapeIds[shapeIds.length - 1];
-                stateCopy.selected = selectShape(stateCopy.selected, addedShapeId);
-                stateCopy.selectionBoxes = generateSelectionBoxes(stateCopy.selected, stateCopy.shapes);
-                break;
             case "selectTool":
                 let shiftSelected = 16 in root.menuState.currentKeys;
                 if (stateCopy.selected.indexOf(action.payload.shapeId) < 0) {
@@ -64,10 +47,6 @@ export function drag(stateCopy, action, root) {
         }
     } else {
         switch (root.menuState.toolType) {
-            case "rectangleTool":
-                stateCopy.shapes = resizeShape(stateCopy.shapes, stateCopy.selected, draggableData, 1);
-                stateCopy.selectionBoxes = updateSelectionBoxes(stateCopy.shapes, stateCopy.selectionBoxes);
-                break;
             case "selectTool":
                 stateCopy.shapes = moveShape(stateCopy.shapes, stateCopy.selected, action);
                 stateCopy.selectionBoxes = generateSelectionBoxes(stateCopy.selected, stateCopy.shapes);


### PR DESCRIPTION
Changes our previous scheme where we had to define nearly identical actions for shapeDrag vs. canvasDrag when rectangleTool is selected.

Now specify when a shape should propagate the event to canvas.