### PR TITLE
Display Shapes of Type 'line' and 'path'

### DIFF
--- a/src/components/drawing/Canvas.js
+++ b/src/components/drawing/Canvas.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import './Canvas.css';
 import { Draggable } from '../shared';
-import { Group, Rectangle, Handle } from '.';
+import { Group, Rectangle, Path, Line, Handle } from '.';
 
 class Canvas extends Component {
     static propTypes = {
@@ -170,12 +170,35 @@ class Canvas extends Component {
                 return (
                     <Rectangle
                         key={shape.id}
-                        id={shape.id}
+                        {...shape}
                         onDragStart={this.handleShapeDragStart}
                         onDrag={this.handleShapeDrag}
                         onDragStop={this.handleShapeDragStop}
                         onClick={this.handleShapeClick}
+                        propagateEvents={propagateEvents}
+                    />
+                );
+            case 'path':
+                return (
+                    <Path
+                        key={shape.id}
                         {...shape}
+                        onDragStart={this.handleShapeDragStart}
+                        onDrag={this.handleShapeDrag}
+                        onDragStop={this.handleShapeDragStop}
+                        onClick={this.handleShapeClick}
+                        propagateEvents={propagateEvents}
+                    />
+                );
+            case 'line':
+                return (
+                    <Line
+                        key={shape.id}
+                        {...shape}
+                        onDragStart={this.handleShapeDragStart}
+                        onDrag={this.handleShapeDrag}
+                        onDragStop={this.handleShapeDragStop}
+                        onClick={this.handleShapeClick}
                         propagateEvents={propagateEvents}
                     />
                 );

--- a/src/components/drawing/Line.js
+++ b/src/components/drawing/Line.js
@@ -1,19 +1,18 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Shape } from '.';
-import { formatTransform } from '../../utilities/shapes';
+import { Path } from '.';
 
-class Rectangle extends Component {
+class Line extends Component {
     static propTypes = {
         id: PropTypes.string,
         onDragStart: PropTypes.func,
         onDrag: PropTypes.func,
         onDragStop: PropTypes.func,
         onClick: PropTypes.func,
-        width: PropTypes.number,
-        height: PropTypes.number,
-        x: PropTypes.number,
-        y: PropTypes.number,
+        x1: PropTypes.number,
+        y1: PropTypes.number,
+        x2: PropTypes.number,
+        y2: PropTypes.number,
         stroke: PropTypes.string,
         strokeWidth: PropTypes.number,
         fill: PropTypes.string,
@@ -58,42 +57,26 @@ class Rectangle extends Component {
     }
 
     render() {
-        const { id, width, height, x, y, stroke, strokeWidth, fill, transform, propagateEvents } = this.props;
-        let renderX = x;
-        let renderWidth = Math.abs(width);
-        if (width < 0) {
-            renderX = x - renderWidth;
-        }
-        let renderY = y;
-        let renderHeight = Math.abs(height);
-        if (height < 0) {
-            renderY = y - renderHeight;
-        }
-        const rectProps = {
-            id,
-            x: renderX,
-            y: renderY,
-            width: renderWidth,
-            height: renderHeight,
+        const { id, x1, y1, x2, y2, stroke, strokeWidth, transform, propagateEvents } = this.props;
+        const lineProps = {
+            d: [{command: 'M', parameters: [x1, y1]}, {command: 'L', parameters: [x2, y2]}],
             stroke,
             strokeWidth,
-            fill,
-            transform: formatTransform(transform)
+            transform
         };
 
         return (
-            <Shape
+            <Path
                 id={id}
                 onDragStart={this.handleDragStart}
                 onDrag={this.handleDrag}
                 onDragStop={this.handleDragStop}
                 onClick={this.handleClick}
+                {...lineProps}
                 propagateEvents={propagateEvents}
-            >
-                <rect {...rectProps} />
-            </Shape>
+            />
         );
     }
 }
 
-export default Rectangle;
+export default Line;

--- a/src/components/drawing/Path.js
+++ b/src/components/drawing/Path.js
@@ -1,19 +1,19 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Shape } from '.';
-import { formatTransform } from '../../utilities/shapes';
+import { formatPath, formatTransform } from '../../utilities/shapes';
 
-class Rectangle extends Component {
+class Path extends Component {
     static propTypes = {
         id: PropTypes.string,
         onDragStart: PropTypes.func,
         onDrag: PropTypes.func,
         onDragStop: PropTypes.func,
         onClick: PropTypes.func,
-        width: PropTypes.number,
-        height: PropTypes.number,
-        x: PropTypes.number,
-        y: PropTypes.number,
+        d: PropTypes.arrayOf(PropTypes.shape({
+            command: PropTypes.string,
+            parameters: PropTypes.arrayOf(PropTypes.number)
+        })),
         stroke: PropTypes.string,
         strokeWidth: PropTypes.number,
         fill: PropTypes.string,
@@ -58,26 +58,13 @@ class Rectangle extends Component {
     }
 
     render() {
-        const { id, width, height, x, y, stroke, strokeWidth, fill, transform, propagateEvents } = this.props;
-        let renderX = x;
-        let renderWidth = Math.abs(width);
-        if (width < 0) {
-            renderX = x - renderWidth;
-        }
-        let renderY = y;
-        let renderHeight = Math.abs(height);
-        if (height < 0) {
-            renderY = y - renderHeight;
-        }
-        const rectProps = {
+        const { id, d, stroke, strokeWidth, fill, transform, propagateEvents } = this.props;
+        const pathProps = {
             id,
-            x: renderX,
-            y: renderY,
-            width: renderWidth,
-            height: renderHeight,
+            d: formatPath(d),
             stroke,
             strokeWidth,
-            fill,
+            fill: fill || 'none',
             transform: formatTransform(transform)
         };
 
@@ -90,10 +77,10 @@ class Rectangle extends Component {
                 onClick={this.handleClick}
                 propagateEvents={propagateEvents}
             >
-                <rect {...rectProps} />
+                <path {...pathProps} />
             </Shape>
         );
     }
 }
 
-export default Rectangle;
+export default Path;

--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -2,4 +2,6 @@ export {default as CanvasContainer} from './CanvasContainer';
 export {default as Shape} from './Shape';
 export {default as Group} from './Group';
 export {default as Rectangle} from './Rectangle';
+export {default as Path} from './Path';
+export {default as Line} from './Line';
 export {default as Handle} from './Handle';

--- a/src/components/left-menu/LeftMenu.js
+++ b/src/components/left-menu/LeftMenu.js
@@ -28,6 +28,9 @@ class LeftMenu extends Component {
                     <button onClick={() => this.handleToolSelect("rectangleTool")}>
                         <img src="./assets/002-frame.svg" alt="rect" id="button-icon" />
                     </button>
+                    <button onClick={() => this.handleToolSelect("lineTool")}>
+                        <img src="./assets/002-frame.svg" alt="line" id="button-icon" />
+                    </button>
                 </div>
             </div>
         );

--- a/src/utilities/shapes.js
+++ b/src/utilities/shapes.js
@@ -1,0 +1,28 @@
+export function formatPath(d) {
+    if (!d) {
+        return '';
+    }
+    let formattedD = '';
+    d.map(command => {
+        formattedD = formattedD + command.command + ' ';
+        command.parameters.map(parameter => {
+            formattedD = formattedD + parameter + ' ';
+        });
+    });
+    return formattedD;
+}
+
+export function formatTransform(transform) {
+    if (!transform) {
+        return '';
+    }
+    let formattedTransform = '';
+    transform.map(command => {
+        formattedTransform = formattedTransform + command.command + '(';
+        command.parameters.map(parameter => {
+            formattedTransform = formattedTransform + parameter + ' ';
+        });
+        formattedTransform = formattedTransform + ') ';
+    });
+    return formattedTransform;
+}


### PR DESCRIPTION
Now if there are shapes of type 'line' or 'path' in drawingState.shapes, the canvas will render them.

Path shapes look like:
```
{
   id: '1312',
   type: ‘path’,
   d: [{command: ‘M’, parameters: [600, 800]}, {command: ‘C’, parameters: [625, 700, 725, 700, 750, 800]}, {command: ‘S’, parameters: [875, 900, 900,     800]}],
   transform: [{command: ‘translate’, parameters: [-300, -500]}],
   stroke: ‘rgba(255, 0, 0, 1    )’
}
```

Lines look like:
```
{
   id: “1212”,
   type: ‘line’,
   x1: 100,
   y1: 100,
   x2: 700,
   y2: 700,
   stroke: ‘rgba(    0, 255, 0, 1)’
}
```

This PR also allows Rectangles to take in a transformation prop in this same format. For a transformation matrix:
```transfrom: [{command: 'matrix', parameters: [0, 0, 0, 0, 0, 0]}]```