### PR TITLE
Ellipses, Rotate Tool, Send front / back

### DIFF
--- a/src/actions/menu.js
+++ b/src/actions/menu.js
@@ -9,6 +9,8 @@ export const ZOOM_IN = 'ZOOM_IN';
 export const ZOOM_OUT = 'ZOOM_OUT';
 export const GROUP_BUTTON_CLICK = 'GROUP_BUTTON_CLICK';
 export const UNGROUP_BUTTON_CLICK = 'UNGROUP_BUTTON_CLICK';
+export const MOVE_BACKWARD = 'MOVE_BACKWARD';
+export const MOVE_FORWARD = 'MOVE_FORWARD';
 export const SEND_BACK = 'SEND_BACK';
 export const BRING_FRONT = 'BRING_FRONT';
 
@@ -54,6 +56,14 @@ export function groupButtonClick() {
 
 export function ungroupButtonClick() {
     return { type: UNGROUP_BUTTON_CLICK };
+}
+
+export function moveBackward() {
+    return { type: MOVE_BACKWARD };
+}
+
+export function moveForward() {
+    return { type: MOVE_FORWARD };
 }
 
 export function sendToBack() {

--- a/src/components/drawing/Canvas.js
+++ b/src/components/drawing/Canvas.js
@@ -2,7 +2,16 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import './Canvas.css';
 import { Draggable } from '../shared';
-import { BackgroundLayerContainer, GridLayerContainer, SelectionLayerContainer, Group, Rectangle, Path, Line } from '.';
+import {
+    BackgroundLayerContainer,
+    GridLayerContainer,
+    SelectionLayerContainer,
+    Group,
+    Rectangle,
+    Ellipse,
+    Path,
+    Line
+} from '.';
 
 class Canvas extends Component {
     static propTypes = {
@@ -138,6 +147,18 @@ class Canvas extends Component {
             case 'rectangle':
                 return (
                     <Rectangle
+                        key={shape.id}
+                        {...shape}
+                        onDragStart={this.handleShapeDragStart}
+                        onDrag={this.handleShapeDrag}
+                        onDragStop={this.handleShapeDragStop}
+                        onClick={this.handleShapeClick}
+                        propagateEvents={propagateEvents}
+                    />
+                );
+            case 'ellipse':
+                return (
+                    <Ellipse
                         key={shape.id}
                         {...shape}
                         onDragStart={this.handleShapeDragStart}

--- a/src/components/drawing/Ellipse.js
+++ b/src/components/drawing/Ellipse.js
@@ -1,18 +1,21 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Path } from '.';
+import { Shape } from '.';
+import { formatTransform } from '../../utilities/shapes';
 
-class Line extends Component {
+class Ellipse extends Component {
     static propTypes = {
         id: PropTypes.string,
         onDragStart: PropTypes.func,
         onDrag: PropTypes.func,
         onDragStop: PropTypes.func,
         onClick: PropTypes.func,
-        x1: PropTypes.number,
-        y1: PropTypes.number,
-        x2: PropTypes.number,
-        y2: PropTypes.number,
+        width: PropTypes.number,
+        height: PropTypes.number,
+        cx: PropTypes.number,
+        cy: PropTypes.number,
+        rx: PropTypes.number,
+        ry: PropTypes.number,
         stroke: PropTypes.string,
         strokeWidth: PropTypes.number,
         fill: PropTypes.string,
@@ -57,26 +60,45 @@ class Line extends Component {
     }
 
     render() {
-        const { id, x1, y1, x2, y2, stroke, strokeWidth, transform, propagateEvents } = this.props;
-        const svgProps = {
-            d: [{command: 'M', parameters: [x1, y1]}, {command: 'L', parameters: [x2, y2]}],
+        const {
+            id,
+            cx,
+            cy,
+            rx,
+            ry,
             stroke,
             strokeWidth,
-            transform
+            fill,
+            transform,
+            propagateEvents
+        } = this.props;
+
+        const svgProps = {
+            id,
+            cx,
+            cy,
+            rx,
+            ry,
+            stroke,
+            strokeWidth,
+            fill,
+            transform: formatTransform(transform),
+            vectorEffect: "non-scaling-stroke"
         };
 
         return (
-            <Path
+            <Shape
                 id={id}
                 onDragStart={this.handleDragStart}
                 onDrag={this.handleDrag}
                 onDragStop={this.handleDragStop}
                 onClick={this.handleClick}
-                {...svgProps}
                 propagateEvents={propagateEvents}
-            />
+            >
+                <ellipse {...svgProps} />
+            </Shape>
         );
     }
 }
 
-export default Line;
+export default Ellipse;

--- a/src/components/drawing/Path.js
+++ b/src/components/drawing/Path.js
@@ -59,7 +59,7 @@ class Path extends Component {
 
     render() {
         const { id, d, stroke, strokeWidth, fill, transform, propagateEvents } = this.props;
-        const pathProps = {
+        const svgProps = {
             id,
             d: formatPath(d),
             stroke,
@@ -77,7 +77,7 @@ class Path extends Component {
                 onClick={this.handleClick}
                 propagateEvents={propagateEvents}
             >
-                <path {...pathProps} />
+                <path {...svgProps} />
             </Shape>
         );
     }

--- a/src/components/drawing/Rectangle.js
+++ b/src/components/drawing/Rectangle.js
@@ -60,29 +60,32 @@ class Rectangle extends Component {
     }
 
     render() {
-        const { id, width, height, x, y, stroke, strokeWidth, strokeDasharray, fill, transform, propagateEvents } = this.props;
-        let renderX = x;
-        let renderWidth = Math.abs(width);
-        if (width < 0) {
-            renderX = x - renderWidth;
-        }
-        let renderY = y;
-        let renderHeight = Math.abs(height);
-        if (height < 0) {
-            renderY = y - renderHeight;
-        }
-        const rectProps = {
+        const {
             id,
-            x: renderX,
-            y: renderY,
-            width: renderWidth,
-            height: renderHeight,
+            width,
+            height,
+            x,
+            y,
+            stroke,
+            strokeWidth,
+            strokeDasharray,
+            fill,
+            transform,
+            propagateEvents
+        } = this.props;
+
+        const svgProps = {
+            id,
+            x,
+            y,
+            width,
+            height,
             stroke,
             strokeWidth,
             strokeDasharray,
             fill,
             transform: formatTransform(transform),
-            vectorEffect: "non-scaling-stroke"
+            vectorEffect: 'non-scaling-stroke'
         };
 
         return (
@@ -94,7 +97,7 @@ class Rectangle extends Component {
                 onClick={this.handleClick}
                 propagateEvents={propagateEvents}
             >
-                <rect {...rectProps} />
+                <rect {...svgProps} />
             </Shape>
         );
     }

--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -5,6 +5,7 @@ export {default as SelectionLayerContainer} from './SelectionLayerContainer';
 export {default as Shape} from './Shape';
 export {default as Group} from './Group';
 export {default as Rectangle} from './Rectangle';
+export {default as Ellipse} from './Ellipse';
 export {default as Path} from './Path';
 export {default as Line} from './Line';
 export {default as Handle} from './Handle';

--- a/src/components/top-menu/TopMenu.js
+++ b/src/components/top-menu/TopMenu.js
@@ -14,6 +14,8 @@ class TopMenu extends Component {
         onGroupClick: PropTypes.func,
         onUngroupClick: PropTypes.func,
         onColorSelect: PropTypes.func,
+        onMoveBackward: PropTypes.func,
+        onMoveForward: PropTypes.func,
         onSendToBack: PropTypes.func,
         onBringToFront: PropTypes.func,
         scale: PropTypes.number
@@ -29,6 +31,8 @@ class TopMenu extends Component {
         this.handleZoomOut = this.handleZoomOut.bind(this);
         this.handleGroupClick = this.handleGroupClick.bind(this);
         this.handleUngroupClick = this.handleUngroupClick.bind(this);
+        this.handleMoveBackward = this.handleMoveBackward.bind(this);
+        this.handleMoveForward = this.handleMoveForward.bind(this);
         this.handleSendToBack = this.handleSendToBack.bind(this);
         this.handleBringToFront = this.handleBringToFront.bind(this);
     }
@@ -47,6 +51,14 @@ class TopMenu extends Component {
 
     handleUngroupClick() {
         this.props.onUngroupClick();
+    }
+
+    handleMoveForward() {
+        this.props.onMoveForward();
+    }
+
+    handleMoveBackward() {
+        this.props.onMoveBackward();
     }
 
     handleBringToFront() {
@@ -85,10 +97,10 @@ class TopMenu extends Component {
                 <button onClick={this.handleUngroupClick}>
                     <img src="./assets/ungroup.svg" alt="ungroup" id="button-icon" />
                 </button>
-                <button onClick={this.handleSendToBack}>
+                <button onClick={this.handleMoveForward}>
                     <img src="./assets/upone.svg" alt="upone" id="button-icon" />
                 </button>
-                <button onClick={this.handleBringToFront}>
+                <button onClick={this.handleMoveBackward}>
                     <img src="./assets/backone.svg" alt="downone" id="button-icon" />
                 </button>
                 <button onClick={this.handleSendToBack}>

--- a/src/components/top-menu/TopMenuContainer.js
+++ b/src/components/top-menu/TopMenuContainer.js
@@ -8,6 +8,8 @@ import {
     zoomOut,
     groupButtonClick,
     ungroupButtonClick,
+    moveBackward,
+    moveForward,
     sendToBack,
     bringToFront
 } from './../../actions/menu';
@@ -31,6 +33,12 @@ const mapDispatchToProps = (dispatch) => {
         },
         onUngroupClick: () => {
             dispatch(ungroupButtonClick());
+        },
+        onMoveBackward: () => {
+            dispatch(moveBackward());
+        },
+        onMoveForward: () => {
+            dispatch(moveForward());
         },
         onSendToBack: () => {
             dispatch(sendToBack());

--- a/src/reducers/caseFunctions/shape.js
+++ b/src/reducers/caseFunctions/shape.js
@@ -1,4 +1,4 @@
-import { resizeShape, moveShape, rotateShape, fillShape, changeZIndex, deleteShapes } from '../utilities/shapes';
+import { resizeShape, moveShape, rotateShape, fillShape, changeZIndex, bringToFront, sendToBack, deleteShapes } from '../utilities/shapes';
 import { selectShape } from '../utilities/selection';
 
 export function click(stateCopy, action, root) {
@@ -79,12 +79,10 @@ export function handleDrag(stateCopy, action, root) {
         const { draggableData, handleIndex, shapeId } = action.payload;
         switch (root.menuState.toolType) {
             case "selectTool":
-                let shiftSelected = 16 in root.menuState.currentKeys;
-                if (shiftSelected) {
-                    stateCopy.shapes = rotateShape(stateCopy.shapes, stateCopy.boundingBoxes, stateCopy.selected, draggableData, handleIndex, stateCopy.scale, stateCopy.selectionBoxes);
-                } else {
-                    stateCopy.shapes = resizeShape(stateCopy.shapes, stateCopy.boundingBoxes, stateCopy.selected, draggableData, handleIndex, stateCopy.scale, shapeId);
-                }
+                stateCopy.shapes = resizeShape(stateCopy.shapes, stateCopy.boundingBoxes, stateCopy.selected, draggableData, handleIndex, stateCopy.scale, shapeId);
+                break;
+            case "rotateTool":
+                stateCopy.shapes = rotateShape(stateCopy.shapes, stateCopy.boundingBoxes, stateCopy.selected, draggableData, handleIndex, stateCopy.scale, stateCopy.selectionBoxes);
                 break;
             default: break;
         }
@@ -107,15 +105,27 @@ export function setColor(stateCopy, action, root) {
     return stateCopy;
 }
 
-export function bringFront(stateCopy, action, root) {
+export function moveForward(stateCopy, action, root) {
     stateCopy.lastSavedShapes = root.drawingState.shapes;
     stateCopy.shapes = changeZIndex(stateCopy.shapes, stateCopy.selected, 1);
     return stateCopy;
 }
 
-export function sendBack(stateCopy, action, root) {
+export function moveBackward(stateCopy, action, root) {
     stateCopy.lastSavedShapes = root.drawingState.shapes;
     stateCopy.shapes = changeZIndex(stateCopy.shapes, stateCopy.selected, -1);
+    return stateCopy;
+}
+
+export function bringFront(stateCopy, action, root) {
+    stateCopy.lastSavedShapes = root.drawingState.shapes;
+    stateCopy.shapes = bringToFront(stateCopy.shapes, stateCopy.selected);
+    return stateCopy;
+}
+
+export function sendBack(stateCopy, action, root) {
+    stateCopy.lastSavedShapes = root.drawingState.shapes;
+    stateCopy.shapes = sendToBack(stateCopy.shapes, stateCopy.selected);
     return stateCopy;
 }
 

--- a/src/reducers/drawingState.js
+++ b/src/reducers/drawingState.js
@@ -72,6 +72,12 @@ function drawingState(state = initialState, action, root) {
         case menuActions.SELECT_COLOR:
             updatedState = shape.setColor(stateCopy, action, root);
             break;
+        case menuActions.MOVE_FORWARD:
+            updatedState = shape.moveForward(stateCopy, action, root);
+            break;
+        case menuActions.MOVE_BACKWARD:
+            updatedState = shape.moveBackward(stateCopy, action, root);
+            break;
         case menuActions.BRING_FRONT:
             updatedState = shape.bringFront(stateCopy, action, root);
             break;

--- a/src/reducers/utilities/shapes.js
+++ b/src/reducers/utilities/shapes.js
@@ -20,6 +20,25 @@ export function addRectangle(shapes, action, fill, panX, panY, scale) {
     return shapes;
 }
 
+export function addEllipse(shapes, action, fill, panX, panY, scale) {
+    const { draggableData } = action.payload;
+    const { x, y, node } = draggableData;
+    const ellipse = {
+        id: uuidv1(),
+        type: 'ellipse',
+        cx: (x + (panX * scale) - node.getBoundingClientRect().left) / scale,
+        cy: (y + (panY * scale) - node.getBoundingClientRect().top) / scale,
+        rx: 0.5,
+        ry: 0.5,
+        fill: formatColor(fill),
+        transform: [{command: 'matrix', parameters: [1, 0, 0, 1, 0, 0]}]
+    };
+
+    shapes.byId[ellipse.id] = ellipse;
+    shapes.allIds.push(ellipse.id);
+    return shapes;
+}
+
 export function addLine(shapes, action, fill, panX, panY, scale) {
     const { draggableData } = action.payload;
     const { x, y, node } = draggableData;
@@ -94,6 +113,22 @@ export function fillShape(shapes, selected, action) {
 export function formatColor(rgba) {
     const { r, g, b, a } = rgba;
     return 'rgba(' + r + ',' + g + ',' + b + ',' + a + ')';
+}
+
+export function bringToFront(shapes, selected) {
+    for (let i = 0; i < selected.length; i++) {
+        shapes.allIds.splice(shapes.allIds.indexOf(selected[i]), 1);
+        shapes.allIds.push(selected[i]);
+    }
+    return shapes;
+}
+
+export function sendToBack(shapes, selected) {
+    for (let i = 0; i < selected.length; i++) {
+        shapes.allIds.splice(shapes.allIds.indexOf(selected[i]), 1);
+        shapes.allIds = [selected[i]].concat(shapes.allIds);
+    }
+    return shapes;
 }
 
 export function changeZIndex(shapes, selected, change) {


### PR DESCRIPTION
This PR:
- Adds ellipses
- Fixes the annoying design where a shape would remain selected after creating it
- Adds the send to back / bring to front function instead of just moving by one layer for both buttons
- Rotate tool instead of shift + drag