### PR TITLE
Display Text on Canvas

### DIFF
--- a/src/actions/canvas.js
+++ b/src/actions/canvas.js
@@ -12,6 +12,7 @@ export const GROUP_CLICK = 'GROUP_CLICK';
 export const HANDLE_DRAG_START = 'HANDLE_DRAG_START';
 export const HANDLE_DRAG = 'HANDLE_DRAG';
 export const HANDLE_DRAG_STOP = 'HANDLE_DRAG_STOP';
+export const TEXT_INPUT_CHANGE = 'TEXT_INPUT_CHANGE';
 export const UPDATE_BOUNDING_BOXES = 'UPDATE_BOUNDING_BOXES';
 
 export function canvasDrag(draggableData) {
@@ -68,6 +69,10 @@ export function handleDrag(shapeId, handleIndex, draggableData) {
 
 export function handleDragStop(shapeId, handleIndex, draggableData) {
     return { type: HANDLE_DRAG_STOP, payload: { shapeId, handleIndex, draggableData } };
+}
+
+export function textInputChange(shapeId, value) {
+    return { type: TEXT_INPUT_CHANGE, payload: { shapeId, value } };
 }
 
 export function updateBoundingBoxes(boundingBoxes) {

--- a/src/components/drawing/BackgroundLayerContainer.js
+++ b/src/components/drawing/BackgroundLayerContainer.js
@@ -6,7 +6,7 @@ const mapStateToProps = ({ drawingState }) => {
     return {
         width: canvasWidth,
         height: canvasHeight,
-        fill: 'black'
+        fill: 'white'
     };
 };
 

--- a/src/components/drawing/Canvas.js
+++ b/src/components/drawing/Canvas.js
@@ -10,7 +10,8 @@ import {
     Rectangle,
     Ellipse,
     Path,
-    Line
+    Line,
+    Text
 } from '.';
 
 class Canvas extends Component {
@@ -126,6 +127,16 @@ class Canvas extends Component {
 
     renderShape(shape) {
         const { propagateEvents } = this.props;
+        const shapeProps = {
+            ...shape,
+            key: shape.id,
+            onDragStart: this.handleShapeDragStart,
+            onDrag: this.handleShapeDrag,
+            onDragStop: this.handleShapeDragStop,
+            onClick: this.handleShapeClick,
+            propagateEvents: propagateEvents
+        };
+
         switch (shape.type) {
             case 'group':
                 const groupMembers = shape.members.map((shape) => {
@@ -145,53 +156,15 @@ class Canvas extends Component {
                     </Group>
                 );
             case 'rectangle':
-                return (
-                    <Rectangle
-                        key={shape.id}
-                        {...shape}
-                        onDragStart={this.handleShapeDragStart}
-                        onDrag={this.handleShapeDrag}
-                        onDragStop={this.handleShapeDragStop}
-                        onClick={this.handleShapeClick}
-                        propagateEvents={propagateEvents}
-                    />
-                );
+                return <Rectangle {...shapeProps} />;
             case 'ellipse':
-                return (
-                    <Ellipse
-                        key={shape.id}
-                        {...shape}
-                        onDragStart={this.handleShapeDragStart}
-                        onDrag={this.handleShapeDrag}
-                        onDragStop={this.handleShapeDragStop}
-                        onClick={this.handleShapeClick}
-                        propagateEvents={propagateEvents}
-                    />
-                );
+                return <Ellipse {...shapeProps} />;
             case 'path':
-                return (
-                    <Path
-                        key={shape.id}
-                        {...shape}
-                        onDragStart={this.handleShapeDragStart}
-                        onDrag={this.handleShapeDrag}
-                        onDragStop={this.handleShapeDragStop}
-                        onClick={this.handleShapeClick}
-                        propagateEvents={propagateEvents}
-                    />
-                );
+                return <Path {...shapeProps} />;
             case 'line':
-                return (
-                    <Line
-                        key={shape.id}
-                        {...shape}
-                        onDragStart={this.handleShapeDragStart}
-                        onDrag={this.handleShapeDrag}
-                        onDragStop={this.handleShapeDragStop}
-                        onClick={this.handleShapeClick}
-                        propagateEvents={propagateEvents}
-                    />
-                );
+                return <Line {...shapeProps} />;
+            case 'text':
+                return <Text {...shapeProps} />;
             default:
                 break;
         }

--- a/src/components/drawing/Canvas.js
+++ b/src/components/drawing/Canvas.js
@@ -6,6 +6,7 @@ import {
     BackgroundLayerContainer,
     GridLayerContainer,
     SelectionLayerContainer,
+    TextInputLayerContainer,
     Group,
     Rectangle,
     Ellipse,
@@ -199,6 +200,7 @@ class Canvas extends Component {
                         <SelectionLayerContainer />
                     </svg>
                 </Draggable>
+                <TextInputLayerContainer />
             </div>
         );
     }

--- a/src/components/drawing/CanvasContainer.js
+++ b/src/components/drawing/CanvasContainer.js
@@ -29,7 +29,7 @@ function formatShape(shape, shapes) {
 }
 
 const mapStateToProps = ({ drawingState, menuState }) => {
-    const { shapes, selected, canvasHeight, canvasWidth, scale } = drawingState;
+    const { shapes, selected, canvasHeight, canvasWidth, textInput, scale } = drawingState;
     const { toolType } = menuState;
     const shapesArray = shapes.allIds.map((id) => {
         return formatShape(shapes.byId[id], shapes);
@@ -41,6 +41,7 @@ const mapStateToProps = ({ drawingState, menuState }) => {
         canvasHeight: canvasHeight * scale,
         canvasWidth: canvasWidth * scale,
         viewBox: [drawingState.panX, drawingState.panY, canvasWidth, canvasHeight],
+        textInput,
         propagateEvents: toolType === 'rectangleTool' || toolType === 'ellipseTool' || toolType === 'lineTool' || toolType === 'panTool' || toolType === 'zoomTool'
     };
 };

--- a/src/components/drawing/SelectionLayerContainer.js
+++ b/src/components/drawing/SelectionLayerContainer.js
@@ -2,6 +2,14 @@ import { connect } from 'react-redux';
 import SelectionLayer from './SelectionLayer';
 import { handleDragStart, handleDrag, handleDragStop } from './../../actions/canvas';
 
+const propagateEventTools = [
+    'rectangleTool',
+    'lineTool',
+    'textTool',
+    'panTool',
+    'zoomTool'
+];
+
 const mapStateToProps = ({ drawingState, menuState }) => {
     const { selectionBoxes } = drawingState;
     const { toolType } = menuState;
@@ -13,7 +21,7 @@ const mapStateToProps = ({ drawingState, menuState }) => {
         selectionBoxes: selectionBoxesArray,
         marqueeBox: drawingState.marqueeBox,
         scale: drawingState.scale,
-        propagateEvents: toolType === 'rectangleTool' || toolType === 'lineTool' || toolType === 'panTool' || toolType === 'zoomTool'
+        propagateEvents: propagateEventTools.indexOf(toolType) > -1
     };
 };
 

--- a/src/components/drawing/Text.js
+++ b/src/components/drawing/Text.js
@@ -1,0 +1,97 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Shape } from '.';
+import { formatTransform } from '../../utilities/shapes';
+
+class Text extends Component {
+    static propTypes = {
+        id: PropTypes.string,
+        onDragStart: PropTypes.func,
+        onDrag: PropTypes.func,
+        onDragStop: PropTypes.func,
+        onClick: PropTypes.func,
+        text: PropTypes.string,
+        x: PropTypes.number,
+        y: PropTypes.number,
+        tspans: PropTypes.arrayOf(PropTypes.shape({
+            indices: PropTypes.arrayOf(PropTypes.shape({
+                first: PropTypes.number,
+                last: PropTypes.number
+            })),
+            style: PropTypes.object
+        })),
+        transform: PropTypes.arrayOf(PropTypes.shape({
+            command: PropTypes.string,
+            parameters: PropTypes.arrayOf(PropTypes.number)
+        })),
+        propagateEvents: PropTypes.bool
+    }
+
+    defaultProps = {
+        propagateEvents: false
+    }
+
+    constructor(props) {
+        super(props);
+
+        this.handleDragStart = this.handleDragStart.bind(this);
+        this.handleDrag = this.handleDrag.bind(this);
+        this.handleDragStop = this.handleDragStop.bind(this);
+        this.handleClick = this.handleClick.bind(this);
+    }
+
+    handleDragStart(id, draggableData) {
+        const { onDragStart } = this.props;
+        onDragStart && onDragStart(id, draggableData);
+    }
+
+    handleDrag(id, draggableData) {
+        const { onDrag } = this.props;
+        onDrag && onDrag(id, draggableData);
+    }
+
+    handleDragStop(id, draggableData) {
+        const { onDragStop } = this.props;
+        onDragStop && onDragStop(id, draggableData);
+    }
+
+    handleClick(id, event) {
+        const { onClick } = this.props;
+        onClick && onClick(id, event);
+    }
+
+    render() {
+        const { id, x, y, tspans, transform, propagateEvents, text } = this.props;
+        const svgProps = {
+            id,
+            x,
+            y,
+            transform: formatTransform(transform)
+        };
+
+        const element = tspans ? tspans.map(tspan => {
+            return (
+                <tspan style={tspan.style}>
+                    {text.slice(tspan.indices.first, tspan.indices.last)}
+                </tspan>
+            );
+        }) : text;
+
+        return (
+            <Shape
+                id={id}
+                onDragStart={this.handleDragStart}
+                onDrag={this.handleDrag}
+                onDragStop={this.handleDragStop}
+                onClick={this.handleClick}
+                propagateEvents={propagateEvents}
+            >
+                <text {...svgProps}>
+                    {element}
+                </text>
+            </Shape>
+        );
+    }
+}
+
+export default Text;

--- a/src/components/drawing/TextInputLayer.js
+++ b/src/components/drawing/TextInputLayer.js
@@ -1,0 +1,54 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class TextInputLayer extends Component {
+    static propTypes = {
+        textInputs: PropTypes.shape({
+            id: PropTypes.shape({
+                id: PropTypes.string,
+                shapeId: PropTypes.string,
+                value: PropTypes.number,
+                x: PropTypes.number,
+                y: PropTypes.number
+            })
+        }),
+        onHandleTextInputChange: PropTypes.func
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.handleTextInputChange = this.handleTextInputChange.bind(this);
+    }
+
+    handleTextInputChange(event) {
+        const { onHandleTextInputChange } = this.props;
+
+        onHandleTextInputChange(event.target.id, event.target.value);
+    }
+
+    renderInputs() {
+        const { textInputs } = this.props;
+
+        return Object.keys(textInputs).map(textInputId => {
+            const textInput = textInputs[textInputId];
+
+            return (
+                <input
+                    key={textInput.id}
+                    id={textInput.shapeId}
+                    type="text"
+                    value={textInput.value}
+                    onChange={this.handleTextInputChange}
+                    style={{position: 'absolute', top: textInput.y, left: textInput.x, pointerEvents: 'all'}}
+                />
+            );
+        });
+    }
+
+    render() {
+        return <div style={{position: 'absolute', top: 0, bottom: 0, left: 0, right: 0, pointerEvents: 'none'}}>{this.renderInputs()}</div>;
+    }
+}
+
+export default TextInputLayer;

--- a/src/components/drawing/TextInputLayerContainer.js
+++ b/src/components/drawing/TextInputLayerContainer.js
@@ -1,0 +1,21 @@
+import { connect } from 'react-redux';
+import TextInputLayer from './TextInputLayer';
+import { textInputChange } from './../../actions/canvas';
+
+const mapStateToProps = ({ drawingState, menuState }) => {
+    const { textInputs } = drawingState;
+    return { textInputs };
+};
+
+const mapDispatchToProps = (dispatch) => {
+    return {
+        onHandleTextInputChange: (textId, value) => {
+            dispatch(textInputChange(textId, value));
+        }
+    };
+};
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(TextInputLayer);

--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -3,6 +3,7 @@ export {default as CanvasContainer} from './CanvasContainer';
 export {default as GridLayerContainer} from './GridLayerContainer';
 export {default as BackgroundLayerContainer} from './BackgroundLayerContainer';
 export {default as SelectionLayerContainer} from './SelectionLayerContainer';
+export {default as TextInputLayerContainer} from './TextInputLayerContainer';
 
 // Shapes
 export {default as Ellipse} from './Ellipse';

--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -1,11 +1,15 @@
+// Layers
 export {default as CanvasContainer} from './CanvasContainer';
 export {default as GridLayerContainer} from './GridLayerContainer';
 export {default as BackgroundLayerContainer} from './BackgroundLayerContainer';
 export {default as SelectionLayerContainer} from './SelectionLayerContainer';
-export {default as Shape} from './Shape';
-export {default as Group} from './Group';
-export {default as Rectangle} from './Rectangle';
+
+// Shapes
 export {default as Ellipse} from './Ellipse';
-export {default as Path} from './Path';
-export {default as Line} from './Line';
+export {default as Group} from './Group';
 export {default as Handle} from './Handle';
+export {default as Line} from './Line';
+export {default as Path} from './Path';
+export {default as Rectangle} from './Rectangle';
+export {default as Shape} from './Shape';
+export {default as Text} from './Text';

--- a/src/components/left-menu/LeftMenu.js
+++ b/src/components/left-menu/LeftMenu.js
@@ -30,7 +30,7 @@ class LeftMenu extends Component {
                     <button onClick={() => this.handleToolSelect("selectTool")}>
                         <img src="./assets/cursor.svg" alt="select" id="button-icon" />
                     </button>
-                    <button onClick={() => this.handleToolSelect("rectangleTool")}>
+                    <button onClick={() => this.handleToolSelect("textTool")}>
                         <img src="./assets/frame.svg" alt="rect" id="button-icon" />
                     </button>
                     <button onClick={() => this.handleToolSelect("lineTool")}>

--- a/src/components/left-menu/LeftMenu.js
+++ b/src/components/left-menu/LeftMenu.js
@@ -30,7 +30,7 @@ class LeftMenu extends Component {
                     <button onClick={() => this.handleToolSelect("selectTool")}>
                         <img src="./assets/cursor.svg" alt="select" id="button-icon" />
                     </button>
-                    <button onClick={() => this.handleToolSelect("textTool")}>
+                    <button onClick={() => this.handleToolSelect("rectangleTool")}>
                         <img src="./assets/frame.svg" alt="rect" id="button-icon" />
                     </button>
                     <button onClick={() => this.handleToolSelect("lineTool")}>
@@ -50,6 +50,9 @@ class LeftMenu extends Component {
                     </button>
                     <button onClick={() => this.handleToolSelect("zoomTool")}>
                         <img src="./assets/marquee-zoom.svg" alt="marquee zoom" id="button-icon" />
+                    </button>
+                    <button onClick={() => this.handleToolSelect("textTool")}>
+                        <img src="./assets/frame.svg" alt="rect" id="button-icon" />
                     </button>
                 </div>
             </div>

--- a/src/reducers/caseFunctions/canvas.js
+++ b/src/reducers/caseFunctions/canvas.js
@@ -1,5 +1,5 @@
-import { addRectangle, addEllipse, addLine, removeShape, resizeShape, moveLineAnchor } from '../utilities/shapes';
-import { selectShape, updateSelectionBoxes } from '../utilities/selection';
+import { addRectangle, addEllipse, addLine, addText, removeShape, resizeShape, moveLineAnchor } from '../utilities/shapes';
+import { selectShape, updateSelectionBoxes, updateTextInputs } from '../utilities/selection';
 import { transformPoint } from '../utilities/matrix';
 import { addMarqueeBox, resizeMarqueeBox } from '../utilities/marquee';
 import { pan, zoomToMarqueeBox } from '../caseFunctions/zoom';
@@ -23,6 +23,12 @@ export function dragStart(stateCopy, action, root) {
 
         case "lineTool":
             stateCopy.shapes = addLine(stateCopy.shapes, action, root.menuState.color, stateCopy.panX, stateCopy.panY, stateCopy.scale);
+            shapeIds = stateCopy.shapes.allIds;
+            addedShapeId = shapeIds[shapeIds.length - 1];
+            stateCopy.selected = selectShape(stateCopy.selected, addedShapeId);
+            break;
+        case "textTool":
+            stateCopy.shapes = addText(stateCopy.shapes, action, root.menuState.color, stateCopy.panX, stateCopy.panY, stateCopy.scale);
             shapeIds = stateCopy.shapes.allIds;
             addedShapeId = shapeIds[shapeIds.length - 1];
             stateCopy.selected = selectShape(stateCopy.selected, addedShapeId);
@@ -101,5 +107,6 @@ export function handleBoundingBoxUpdate(stateCopy, action, root) {
     const { boundingBoxes } = action.payload;
     stateCopy.boundingBoxes = boundingBoxes;
     stateCopy.selectionBoxes = updateSelectionBoxes(stateCopy.selected, stateCopy.shapes, stateCopy.selectionBoxes, stateCopy.boundingBoxes);
+    stateCopy.textInputs = updateTextInputs(stateCopy.selected, stateCopy.shapes, stateCopy.textInputs);
     return stateCopy;
 }

--- a/src/reducers/caseFunctions/shape.js
+++ b/src/reducers/caseFunctions/shape.js
@@ -99,6 +99,13 @@ export function handleDragStop(stateCopy, action, root) {
     return stateCopy;
 }
 
+export function textInputChange(stateCopy, action, root) {
+    const { shapeId, value } = action.payload;
+    stateCopy.textInputs[shapeId].value = value;
+    stateCopy.shapes.byId[shapeId].text = value;
+    return stateCopy;
+}
+
 export function setColor(stateCopy, action, root) {
     stateCopy.lastSavedShapes = root.drawingState.shapes;
     stateCopy.shapes = fillShape(stateCopy.shapes, stateCopy.selected, action);

--- a/src/reducers/drawingState.js
+++ b/src/reducers/drawingState.js
@@ -20,6 +20,7 @@ const initialState = {
     editInProgress: false,
     canvasHeight: 850,
     canvasWidth: 1000,
+    textInputs: {},
     scale: 1,
     panX: 0,
     panY: 0,
@@ -65,6 +66,9 @@ function drawingState(state = initialState, action, root) {
             break;
         case canvasActions.HANDLE_DRAG_STOP:
             updatedState = shape.handleDragStop(stateCopy, action, root);
+            break;
+        case canvasActions.TEXT_INPUT_CHANGE:
+            updatedState = shape.textInputChange(stateCopy, action, root);
             break;
         case canvasActions.UPDATE_BOUNDING_BOXES:
             updatedState = canvas.handleBoundingBoxUpdate(stateCopy, action, root);
@@ -129,6 +133,7 @@ function drawingState(state = initialState, action, root) {
             }
         }
     }
+
     return updatedState;
 }
 

--- a/src/reducers/utilities/selection.js
+++ b/src/reducers/utilities/selection.js
@@ -23,6 +23,32 @@ export function selectShape(selected, shapeId, selectMultiple, shiftSelected) {
     return selected;
 }
 
+export function updateTextInputs(selected, shapes, textInputs) {
+    const updatedTextInputs = {};
+    selected.map((id) => {
+        const shape = shapes.byId[id];
+        if (shape.type === 'text') {
+            const textInput = textInputs[id];
+            if (textInput) {
+                textInput.x = shape.x;
+                textInput.y = shape.y;
+                textInput.value = shape.text;
+                updatedTextInputs[id] = textInput;
+            } else {
+                updatedTextInputs[id] = {
+                    id: uuidv1(),
+                    shapeId: id,
+                    x: shape.x,
+                    y: shape.y,
+                    value: shape.text
+                };
+            }
+        }
+    });
+
+    return updatedTextInputs;
+}
+
 export function updateSelectionBoxes(selected, shapes, selectionBoxes, boundingBoxes) {
     const updatedSelectionBoxes = {};
     selected.map((id) => {

--- a/src/reducers/utilities/shapes.js
+++ b/src/reducers/utilities/shapes.js
@@ -60,6 +60,24 @@ export function addLine(shapes, action, fill, panX, panY, scale) {
     return shapes;
 }
 
+export function addText(shapes, action, fill, panX, panY, scale) {
+    const { draggableData } = action.payload;
+    const { x, y, node } = draggableData;
+
+    const text = {
+        id: uuidv1(),
+        type: 'text',
+        text: '',
+        x: (x + (panX * scale) - node.getBoundingClientRect().left) / scale,
+        y: (y + (panY * scale) - node.getBoundingClientRect().top) / scale,
+        transform: [{command: 'matrix', parameters: [1, 0, 0, 1, 0, 0]}]
+    };
+
+    shapes.byId[text.id] = text;
+    shapes.allIds.push(text.id);
+    return shapes;
+}
+
 export function moveLineAnchor(shapes, selected, draggableData, scale) {
     const { deltaX, deltaY } = draggableData;
     const scaledDeltaX = deltaX / scale;


### PR DESCRIPTION
If a shape of type 'text' is in shapes, Canvas.js can render it. Here's an example of the format:
```
{
        type: 'text',
        text: '0123456789',
        x: 50,
        y: 50,
        tspans: [{indices: {first: 0, last: 6}, style: {fill: 'red'}}, {indices: {first: 6, last: 10}, style: {fill: 'blue', baselineShift: 'super'}}]
}
```
`tspan` can be undefined, but otherwise it should be an array of objects which have `indices`, `first` and `last`, to tell us how much of the text the tspan covers and then a style object to apply the tspan-specific style.